### PR TITLE
fix vagrant vm forward_port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-  config.vm.forward_port 80, 8081
+config.vm.network :forwarded_port, guest: 80, host: 8081
 
   # TODO: fix this hack that ensures 'apt-get update' runs before mysql
   # is provisioned with puppet

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,4 @@
-VAGRANTFILE_API_VERSION = "2"
-
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+Vagrant.configure("2") do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.forward_port 80, 8081

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-  config.vm.network :forwarded_port, guest: 80, host: 8081
+  config.vm.forward_port 80, 8081
 
   # TODO: fix this hack that ensures 'apt-get update' runs before mysql
   # is provisioned with puppet


### PR DESCRIPTION
fix vagrant vm forward_port:
There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

/opt/vagrant-phalcon/Vagrantfile:6: syntax error, unexpected ':', expecting kEND
  config.vm.network :forwarded_port, guest: 80, host: 8081
                                           ^

compared with: http://framework.zend.com/svn/framework/standard/trunk/Vagrantfile
