### PR TITLE
Added SCRIPT_FILENAME to fastcgi parameters

### DIFF
--- a/provision/puppet/modules/nginx/templates/includes/fastcgi_params.erb
+++ b/provision/puppet/modules/nginx/templates/includes/fastcgi_params.erb
@@ -3,6 +3,7 @@ fastcgi_param  REQUEST_METHOD     $request_method;
 fastcgi_param  CONTENT_TYPE       $content_type;
 fastcgi_param  CONTENT_LENGTH     $content_length;
 
+fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
 fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
 fastcgi_param  REQUEST_URI        $request_uri;
 fastcgi_param  DOCUMENT_URI       $document_uri;


### PR DESCRIPTION
The router wouldn't work without SCRIPT_FILENAME so I added it into the fastcgi parameters.
